### PR TITLE
Add infra for parallel testing of ASP.NET Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ public class DataIslandFixture
 
                 // This template is using "Sql Server" pool.
                 opt.AddComponent<SqlServerComponent, SqlServerSpec>("SQL Server");
-            })      
-            .Build();
+            })
+            .BuildInProc();
     }
 
     public IDataIsland Island { get; }

--- a/src/DataIsland.Demo/TenantFixture.cs
+++ b/src/DataIsland.Demo/TenantFixture.cs
@@ -82,7 +82,7 @@ public class TenantFixture : IAsyncLifetime
             // fixture is global because it is in assembly fixture.
             // The supplied context is a glue/ambient context that connects
             // the created tenant lake to rest of xUnit infrastructure.
-            .Build();
+            .BuildInProc();
     }
 
     public IDataIsland Island { get; }

--- a/src/DataIsland.xUnit.v3/AspNetTestProvider.cs
+++ b/src/DataIsland.xUnit.v3/AspNetTestProvider.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading;
+
+namespace DataIsland.xUnit.v3;
+
+/// <summary>
+/// A provider of current test for ASP.NET integration tests. The <see cref="TestIdMiddleware"/>
+/// sets and clears <see cref="CurrentTestId"/>. It is registered as a singleton to MSDI container
+/// of tested component.
+/// </summary>
+internal class AspNetTestProvider : ICurrentTestProvider
+{
+    // TODO: This is ugly, but I don't know how to fix it. Provider is built in Build() method, but
+    // I need to access in TestIdMiddleware. Remove ITestContext from DataIsland and just create it
+    // in Build*() methods.
+    private static readonly AsyncLocal<string?> TestId = new();
+
+    public string? CurrentTestId => TestId.Value;
+
+    internal void SetTestId(string? value)
+    {
+        TestId.Value = value;
+    }
+}

--- a/src/DataIsland.xUnit.v3/DataIsland.xUnit.v3.csproj
+++ b/src/DataIsland.xUnit.v3/DataIsland.xUnit.v3.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
     <PackageReference Include="xunit.v3.extensibility.core" Version="0.2.0-pre.69" />
   </ItemGroup>
 

--- a/src/DataIsland.xUnit.v3/DataIslandBuilderExtensions.cs
+++ b/src/DataIsland.xUnit.v3/DataIslandBuilderExtensions.cs
@@ -1,13 +1,43 @@
-﻿using DataIsland.xUnit.v3;
+﻿using System;
+using DataIsland.xUnit.v3;
+using JetBrains.Annotations;
+using Xunit;
 
 // ReSharper disable once CheckNamespace
+// The same namespace as the DataIslandBuilder means IntelliSense will also offer extension methods
+// immediately without need to import additional namespace. Because XunitTestContext is internal,
+// it can only be created by extension methods. Offer them as nif they were instance methods of
+// the DataIslandBuilder.
 namespace DataIsland;
 
 public static class DataIslandBuilderExtensions
 {
     /// <inheritdoc cref="DataIslandBuilder.Build"/>
-    public static IDataIsland Build(this DataIslandBuilder builder)
+    [PublicAPI]
+    public static IDataIsland BuildInProc(this DataIslandBuilder builder)
     {
-        return builder.Build(new XUnitTestContext());
+        return Build(builder, new XUnitTestProvider());
+    }
+
+    /// <inheritdoc cref="DataIslandBuilder.Build"/>
+    [PublicAPI]
+    public static IDataIsland BuildAspNet(this DataIslandBuilder builder)
+    {
+        return Build(builder, new AspNetTestProvider());
+    }
+
+    private static IDataIsland Build(DataIslandBuilder builder, ICurrentTestProvider testProvider)
+    {
+        var testContext = TestContext.Current;
+        if (testContext.PipelineStage == TestPipelineStage.Unknown)
+        {
+            throw new InvalidOperationException("""
+                                                Method was called outside of xUnit test execution pipeline. A shared dictionary
+                                                from xUnit framework that is used to glue various components together is not yet
+                                                initialized.
+                                                """);
+        }
+
+        return builder.Build(new XUnitTestContext(testContext.KeyValueStorage, testProvider));
     }
 }

--- a/src/DataIsland.xUnit.v3/ICurrentTestProvider.cs
+++ b/src/DataIsland.xUnit.v3/ICurrentTestProvider.cs
@@ -1,0 +1,40 @@
+﻿namespace DataIsland.xUnit.v3;
+
+/// <summary>
+/// <para>
+/// A provider that can return a unique identifier of currently running test.
+/// </para>
+/// <para>
+/// This interface is needed, because we can test in two ways:
+/// <list type="bullet">
+///   <item>
+///     <term>InProc</term>
+///     <description>
+///         Test are executed within a single async flow. Generally this means test resolves
+///         dependency, calls some methods and everything is done directly from test method.
+///         For this case, we use <see cref="Xunit.TestContext.Current"/> as an ambient
+///         context used to keep track of currently running test.
+///     </description>
+///   </item>
+///   <item>
+///     <term>Separated</term>
+///     <description>
+///         The test calls some other component through network, generally through loopback.
+///         Ultimately, everything is still running within the same process and all components
+///         can share objects, but they are not connected through some kind of ambient context
+///         that could keep track of currently executed test. We therefore need a way to get
+///         identifier of currently running test. For ASP.NET Core, we sent it as HTTP header
+///         through <see cref="TestIdHandler"/> and the <see cref="TestIdMiddleware"/> sets
+///         it as current test for the processed request.
+///     </description>
+///   </item>
+/// </list>
+/// In both cases, the <see cref="XUnitTestContext"/> test id is necessary to get tenants created
+/// for a test. Patchers resolve the <see cref="ITestContext"/> from MSDI and create patched
+/// data access libraries.
+/// </para>
+/// </summary>
+internal interface ICurrentTestProvider
+{
+    string? CurrentTestId { get; }
+}

--- a/src/DataIsland.xUnit.v3/SharedStorageConstants.cs
+++ b/src/DataIsland.xUnit.v3/SharedStorageConstants.cs
@@ -1,0 +1,26 @@
+﻿using Xunit;
+
+namespace DataIsland.xUnit.v3;
+
+internal static class SharedStorageConstants
+{
+    /// <summary>
+    /// Name of a header that is sent from test case HTTP client to test server. It contains a
+    /// unique identifier of currently running test. The name is used to create a key to
+    /// <see cref="TestContext.KeyValueStorage"/> dictionary that stores tenant map created by
+    /// <see cref="ApplyTemplateAttribute"/>.
+    /// </summary>
+    internal static readonly string TestIdHeaderName = "X-DataIsland-Unique-TestId";
+
+    /// <summary>
+    /// Get a key to shared storage that contains <c>IReadOnlyDictionary&lt;Type, Tenant&gt;</c>.
+    /// The key is a type of data access, the value is a <see cref="Tenant"/> created for current
+    /// test.
+    /// </summary>
+    /// <param name="testId">Identifier of current test.</param>
+    /// <returns>Key to shared storage.</returns>
+    internal static string GetDataAccessMapKey(string testId)
+    {
+        return testId + "-data-access-map";
+    }
+}

--- a/src/DataIsland.xUnit.v3/TestIdHandler.cs
+++ b/src/DataIsland.xUnit.v3/TestIdHandler.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DataIsland.xUnit.v3;
+
+/// <summary>
+/// <para>
+/// A handler that adds HTTP header with identifier of current test to the request sent to the test
+/// server. The identifier is used by a middleware on the server to set the <see cref="ITestContext"/>
+/// that is later used by patched service registrations to resolve data access classes that will
+/// use tenants created for the test.
+/// </para>
+/// <para>
+/// Generally, this handler should be added to HTTP client created by <c>WebApplicationFactory</c>,
+/// through it can be used for any HTTP client created anywhere.
+/// <code>
+/// public SomeWebPageTests(CustomWebApplicationFactory&lt;Program&gt; factory)
+/// {
+///     _client = factory.CreateDefaultClient(new AddTestIdHandler());
+/// }
+/// </code>
+/// </para>
+/// </summary>
+/// <remarks>
+/// The header inserted by the handler is retrieved by <see cref="TestIdMiddleware"/>.
+/// </remarks>
+public class TestIdHandler : DelegatingHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var currentTestContext = TestContext.Current;
+        if (currentTestContext.PipelineStage != TestPipelineStage.TestExecution ||
+            currentTestContext.TestMethod is not { } currentTestMethod)
+        {
+            throw new InvalidOperationException("""
+                                                xUnit is currently not executing a test and handler thus can't determine a
+                                                identifier of current test to send as a HTTP header to the test server. The
+                                                identifier must be transmitted to the test server, so the patched MSDI service
+                                                registrations know which tenants to use for data access libraries.
+                                                """);
+        }
+
+        request.Headers.Add(SharedStorageConstants.TestIdHeaderName, currentTestMethod.UniqueID);
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/src/DataIsland.xUnit.v3/TestIdHeaderStartupFilter.cs
+++ b/src/DataIsland.xUnit.v3/TestIdHeaderStartupFilter.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+
+namespace DataIsland.xUnit.v3;
+
+/// <summary>
+/// <para>
+/// A startup filter that adds <see cref="TestIdMiddleware"/> to the beginning of the ASP.NET Core
+/// pipeline. Startup filters are basically a requirement when test want to add a middleware to an
+/// existing pipeline. The <c>.Configure</c> in a <c>WebApplicationFactory{TEntryPoint}</c>
+/// overrides completely existing the middleware pipeline and is thus unsuitable for adding a
+/// middleware.
+/// </para>
+/// <para>
+/// <code>
+///     protected override void ConfigureWebHost(IWebHostBuilder builder)
+///     {
+///       // DON'T DO THIS: Calling .Configure here replaces whatever middleware was existing in
+///       // the original program. That means no routing and other things that were part of the
+///       // original pipeline.
+///       builder.Configure(app =>
+///       {
+///          method builder.Configure(app => app.UseMiddleware&lt;SomeMiddleware&gt; ());
+///       });
+///     }
+/// </code>
+/// </para>
+/// </summary>
+internal class TestIdHeaderStartupFilter : IStartupFilter
+{
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+    {
+        return builder =>
+        {
+            builder.UseMiddleware<TestIdMiddleware>();
+            next(builder);
+        };
+    }
+}

--- a/src/DataIsland.xUnit.v3/TestIdMiddleware.cs
+++ b/src/DataIsland.xUnit.v3/TestIdMiddleware.cs
@@ -1,0 +1,89 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http;
+using static DataIsland.xUnit.v3.SharedStorageConstants;
+namespace DataIsland.xUnit.v3;
+
+/// <summary>
+/// Middleware that takes <c>testId</c> sent by <see cref="TestIdHandler"/> from a xUnit test and
+/// sets it to the <see cref="ICurrentTestProvider"/> for this request. The <see cref="ICurrentTestProvider"/>
+/// is used by the <see cref="XUnitTestContext"/> to determine where in the shared storage are the tenants for
+/// the current test.
+/// </summary>
+internal class TestIdMiddleware : IMiddleware
+{
+    [UsedImplicitly]
+
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        // Get testId sent by HTTP client from a test.
+        if (!TryGetCurrentTestId(context, out var currentTestId))
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await context.Response.WriteAsync($"""
+                                               Header '{TestIdHeaderName}' must contain exactly one non-empty value.
+                                               The header contains identifier of currently executed test, so MSDI on
+                                               test server knows which tenants to use when resolving data access
+                                               libraries.
+                                               
+                                               Make sure the HttpClient uses {nameof(TestIdHandler)}.
+                                               Example: _client = factory.CreateDefaultClient(new AddTestIdHandler());
+                                               """);
+            return;
+        }
+
+        var untypedTestNameProvider = context.RequestServices.GetService(typeof(AspNetTestProvider));
+        if (untypedTestNameProvider is not AspNetTestProvider testNameProvider)
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await context.Response.WriteAsync($$"""
+                                                The MSDI doesn't contain service {{nameof(AspNetTestProvider)}}.
+
+                                                Make sure you registered it to the WebApplicationFactory.
+                                                Example:
+                                                
+                                                public class CustomWebApplicationFactory<TProgram>(DataIslandFixture _fixture)
+                                                    : WebApplicationFactory<TProgram> where TProgram : class
+                                                {
+                                                  protected override void ConfigureWebHost(IWebHostBuilder builder)
+                                                  {
+                                                    builder.ConfigureTestServices(services =>
+                                                    {
+                                                      services.AddDataIsland<CustomWebApplicationFactory<TProgram>>(_fixture.Island);
+                                                    });
+                                                  }
+                                                }
+                                                """);
+            return;
+        }
+
+        testNameProvider.SetTestId(currentTestId);
+
+        try
+        {
+            await next(context);
+        }
+        finally
+        {
+            testNameProvider.SetTestId(null);
+        }
+    }
+
+    private static bool TryGetCurrentTestId(HttpContext context, out string currentTestId)
+    {
+        currentTestId = string.Empty;
+        if (!context.Request.Headers.TryGetValue(TestIdHeaderName, out var headerValues))
+            return false;
+
+        if (headerValues.Count != 1)
+            return false;
+
+        var currentTestKey = headerValues.Single();
+        if (string.IsNullOrWhiteSpace(currentTestKey))
+            return false;
+
+        currentTestId = currentTestKey;
+        return true;
+    }
+}

--- a/src/DataIsland.xUnit.v3/XUnitTestContext.cs
+++ b/src/DataIsland.xUnit.v3/XUnitTestContext.cs
@@ -3,16 +3,40 @@ using System.Collections.Generic;
 
 namespace DataIsland.xUnit.v3;
 
-internal class XUnitTestContext : ITestContext
+/// <summary>
+/// A context that provides access to tenants created for the test. It is stored in DI and patched
+/// service registrations use it to get tenant.
+/// </summary>
+/// <param name="sharedStorage">
+/// A shared storage that contains all data access maps for all running tests. The
+/// <see cref="ApplyTemplateAttribute"/> creates and stores data access map to the shared storage
+/// and once test is done it removes them from the storage. This is single instance shared across
+/// whole assembly and is not thread safe. Make sure to use
+/// <code>lock (_sharedStorage) { _sharedStorage.Something(); } </code>.
+/// </param>
+/// <param name="testProvider">
+/// A provider of current test id. It is used to determine which tenant map from
+/// <paramref name="sharedStorage"/> should be used.
+/// </param>
+internal class XUnitTestContext(Dictionary<string, object?> sharedStorage, ICurrentTestProvider testProvider) : ITestContext
 {
+    private readonly Dictionary<string, object?> _sharedStorage = sharedStorage ?? throw new ArgumentNullException(nameof(sharedStorage));
+    private readonly ICurrentTestProvider _testProvider = testProvider ?? throw new ArgumentNullException(nameof(testProvider));
+
     public bool HasMaterializedTemplate
     {
         get
         {
-            var ctx = Xunit.TestContext.Current;
-            lock (ctx.KeyValueStorage)
+            // Are we even within a test?
+            var testId = _testProvider.CurrentTestId;
+            if (testId is null)
+                return false;
+
+            // Are we in a test that has [ApplyTemplate] attribute?
+            lock (_sharedStorage)
             {
-                return ctx.KeyValueStorage.ContainsKey(ctx.TestMethod!.UniqueID + "-data-access-map");
+                var dataAccessMapKey = SharedStorageConstants.GetDataAccessMapKey(testId);
+                return _sharedStorage.ContainsKey(dataAccessMapKey);
             }
         }
     }
@@ -21,15 +45,33 @@ internal class XUnitTestContext : ITestContext
     public TTenant GetTenant<TTenant>(Type dataAccessType)
         where TTenant : class
     {
-        var ctx = Xunit.TestContext.Current;
-        lock (ctx.KeyValueStorage)
+        var currentTestId = _testProvider.CurrentTestId;
+        if (currentTestId is null)
         {
-            var untypedDataAccessMap = ctx.KeyValueStorage[ctx.TestMethod!.UniqueID + "-data-access-map"];
-            if (untypedDataAccessMap is null)
-                throw new InvalidOperationException("No data access map.");
+            throw new InvalidOperationException("""
+                                                Unable to determine currently running test.
 
-            if (untypedDataAccessMap is not IReadOnlyDictionary<Type, Tenant> dataAccessMap)
-                throw new InvalidOperationException("Incorrect type for data access map");
+                                                Make sure that: 
+                                                * This `GetTenant` is called from a test method.
+                                                * DataIsland TestContext was built for correct mode (`.BuildInProc()` for
+                                                  tests running directly in the test method, `.BuildAspNet()` for ASP.NET
+                                                  Core integration tests that run on test server.
+                                                """);
+        }
+
+        var dataAccessMapKey = SharedStorageConstants.GetDataAccessMapKey(currentTestId);
+        lock (_sharedStorage)
+        {
+            var dataAccessMap = (IReadOnlyDictionary<Type, Tenant>?)_sharedStorage[dataAccessMapKey];
+            if (dataAccessMap is null)
+            {
+                throw new InvalidOperationException("""
+                                                    Shared storage doesn't contain data access map.
+
+                                                    Make sure that the test (either method or class) has [ApplyTemplate]
+                                                    attribute.
+                                                    """);
+            }
 
             return (TTenant)dataAccessMap[dataAccessType].Instance;
         }

--- a/src/DataIsland.xUnit.v3/XUnitTestProvider.cs
+++ b/src/DataIsland.xUnit.v3/XUnitTestProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace DataIsland.xUnit.v3;
+
+internal class XUnitTestProvider : ICurrentTestProvider
+{
+    public string? CurrentTestId => Xunit.TestContext.Current.TestMethod?.UniqueID;
+}


### PR DESCRIPTION
Originally, only tests that resolved and tested components from MSDI in-process could be tested. That is because we used to use Xunit.TestContext.Current as an ambient context.

The problem is that ASP.NET integration testing doesn't work with that mode. The test server is running in a separate thread. The test creates HttpClient and sends a request over loopback. Therefore, ambient context is lost.

Instead, we are sending testId as a HTTP header with each request and a middleware in test server receives it and sets the testId to the ambinet context in test server request.