### PR TITLE
Remove pool name from DataIsland

### DIFF
--- a/sample/InProc/DataIslandFixture.cs
+++ b/sample/InProc/DataIslandFixture.cs
@@ -54,7 +54,7 @@ public class DataIslandFixture : IAsyncLifetime
         Island = new DataIslandBuilder()
             // Tenant lake will contain only one component - SQL Server defined
             // above.
-            .AddComponentPool("DefaultComponent", componentPool, factory)
+            .AddComponentPool(componentPool, factory)
 
             // For default template, we request the following state of external components:
             .AddTemplate("DefaultTemplate", opt =>

--- a/sample/WebApi.Tests/DataIslandFixture.cs
+++ b/sample/WebApi.Tests/DataIslandFixture.cs
@@ -16,7 +16,7 @@ public class DataIslandFixture
         var factory = new SqlDatabaseTenantFactory(@"c:\Temp\dataisland\files");
 
         Island = new DataIslandBuilder()
-            .AddComponentPool("SQL Server", componentPool, factory)
+            .AddComponentPool(componentPool, factory)
             .AddTemplate("Template", opt =>
             {
                 opt.AddComponent<SqlServerComponent, SqlServerSpec>("SQL Server");

--- a/tests/DataIsland.Core.Tests/DataIslandTests.cs
+++ b/tests/DataIsland.Core.Tests/DataIslandTests.cs
@@ -49,7 +49,7 @@ public class DataIslandTests
         var pool = new Mock<IComponentPool<DummyComponent, DummyComponentSpec>>();
         var factory = new Mock<ITenantFactory<DummyTenant, DummyComponent, DummyTenantSpec>>();
         var sut = new DataIslandBuilder()
-            .AddComponentPool("moq pool", pool.Object, factory.Object)
+            .AddComponentPool(pool.Object, factory.Object)
             .Build();
 
         pool.Verify(x => x.InitializeAsync(default), Times.Never);

--- a/tests/DataIsland.Core.Tests/MaterializerTests.cs
+++ b/tests/DataIsland.Core.Tests/MaterializerTests.cs
@@ -17,7 +17,7 @@ public class MaterializerTests
         factory.Setup(x => x.AddTenantAsync(component, It.IsAny<DummyTenantSpec>())).ReturnsAsync(tenant);
 
         var dataIsland = new DataIslandBuilder()
-            .AddComponentPool("component", pool.Object, factory.Object)
+            .AddComponentPool(pool.Object, factory.Object)
             .AddTemplate("template name", template =>
             {
                 template.AddComponent<DummyComponent, DummyComponentSpec>("component");
@@ -42,7 +42,7 @@ public class MaterializerTests
         var pool = new Mock<IComponentPool<DummyComponent, DummyComponentSpec>>();
         var factory = new Mock<ITenantFactory<DummyTenant, DummyComponent, DummyTenantSpec>>();
         var dataIsland = new DataIslandBuilder()
-            .AddComponentPool("test", pool.Object, factory.Object)
+            .AddComponentPool(pool.Object, factory.Object)
             .Build();
 
         await Assert.ThrowsAsync<KeyNotFoundException>(() => dataIsland.Materializer.MaterializeTenantsAsync("nonexistent template"));
@@ -63,7 +63,7 @@ public class MaterializerTests
         factory.Setup(f => f.AddTenantAsync(component, It.IsAny<DummyTenantSpec>())).ReturnsAsync(tenant);
 
         var dataIsland = new DataIslandBuilder()
-            .AddComponentPool("component", pool.Object, factory.Object)
+            .AddComponentPool(pool.Object, factory.Object)
             .AddTemplate("template", template =>
             {
                 template.AddComponent<DummyComponent, DummyComponentSpec>("component");


### PR DESCRIPTION
There actually is no reason to have a pool name. We are interested in components of a tenant. There can be multiple components per tenant and thus they shoudl have unique name. But there is only one pool per component.