### PR TITLE
Add a hook to call after materialization.

### DIFF
--- a/src/DataIsland.Core/Materializer.cs
+++ b/src/DataIsland.Core/Materializer.cs
@@ -64,6 +64,8 @@ internal class Materializer : IMaterializer
             }
         }
 
+        await template.ApplyAfterInitAsync(tenants);
+
         return tenants;
     }
 


### PR DESCRIPTION
The hook has access to all created tenants for a test.

This is useful if there is a need to do something that requires a coordination of multiple tenants, e.g. linked server.