### PR TITLE
Add custom patcher API

### DIFF
--- a/src/DataIsland.Core/DataIslandBuilder.cs
+++ b/src/DataIsland.Core/DataIslandBuilder.cs
@@ -62,6 +62,31 @@ public class DataIslandBuilder
         return this;
     }
 
+    /// <summary>
+    /// <para>
+    /// Add a custom patcher that resolves the data access from a tenant and service provider.
+    /// </para>
+    /// <para>
+    /// An example of usage: Create a SQL connection to a database created in a test. Note that it
+    /// is still necessary to open the connection:
+    /// <code>
+    ///   builder.AddPatcher&lt;SqlConnection, SqlDatabaseTenant&gt;(
+    ///     (sp, db) => new SqlConnection(db.ConnectionString));
+    /// </code>
+    /// </para>
+    /// </summary>
+    /// <typeparam name="TDataAccess">Type of service to resolve. A library to access <typeparamref name="TTenant"/>.</typeparam>
+    /// <typeparam name="TTenant">A data store.</typeparam>
+    /// <param name="factoryMethod">A factory method that will receive tenant instantiated for a
+    ///     test and should return instance of <typeparamref name="TDataAccess"/> that accesses data
+    ///     from <typeparamref name="TTenant"/>.</param>
+    /// <returns>This data builder for fluent API.</returns>
+    public DataIslandBuilder AddPatcher<TDataAccess, TTenant>(Func<IServiceProvider, TTenant, TDataAccess> factoryMethod)
+        where TTenant : class
+    {
+        return AddPatcher(new LambdaPatcher<TDataAccess, TTenant>(factoryMethod));
+    }
+
     public IDataIsland Build()
     {
         foreach (var (templateName, template) in _templates)

--- a/src/DataIsland.Core/DynamicCaller.cs
+++ b/src/DataIsland.Core/DynamicCaller.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection;
 using System.Threading.Tasks;
 using ITenantFactory = object;
 using IDependencyPatcher = object;
@@ -16,7 +17,14 @@ internal static class DynamicCaller
         var patcherInterface = typeof(IDependencyPatcher<>).MakeGenericType(dataAccessType);
         var registerMethod = patcherInterface.GetMethod("Register");
         Debug.Assert(registerMethod is not null);
-        registerMethod.Invoke(patcher, [services]);
+        try
+        {
+            registerMethod.Invoke(patcher, [services]);
+        }
+        catch (TargetInvocationException ex)
+        {
+            throw ex.GetBaseException();
+        }
     }
 
     /// <inheritdoc cref="IComponentPool{TComponent,TComponentSpec}.AcquireComponentsAsync"/>

--- a/src/DataIsland.Core/LambdaPatcher.cs
+++ b/src/DataIsland.Core/LambdaPatcher.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace DataIsland;
+
+internal class LambdaPatcher<TDataAccess, TTenant>(Func<IServiceProvider, TTenant, TDataAccess> _factoryMethod)
+    : IDependencyPatcher<TDataAccess>
+    where TDataAccess : notnull
+    where TTenant : class
+{
+    public void Register(IServiceCollection serviceCollection)
+    {
+        var originalRegistrations = serviceCollection.Where(x => x.ServiceType == typeof(TDataAccess)).ToList();
+        if (originalRegistrations.Count == 0)
+            throw new InvalidOperationException($"Service {typeof(TDataAccess)} isn't in the service collection - it can't be patched. Ensure the service is registered as a service before calling the patch method to patch the registration.");
+
+        var replacements = new List<ServiceDescriptor>(originalRegistrations.Count);
+        foreach (var registration in originalRegistrations)
+        {
+            replacements.Add(new ServiceDescriptor(typeof(TDataAccess), sp =>
+            {
+                var testContext = sp.GetRequiredService<ITestContext>();
+                var tenant = testContext.GetTenant<TTenant>(typeof(TDataAccess));
+                return _factoryMethod(sp, tenant);
+            }, registration.Lifetime));
+        }
+
+        serviceCollection.RemoveAll(typeof(TDataAccess));
+        serviceCollection.Add(replacements);
+    }
+}

--- a/tests/DataIsland.Core.Tests/DataIsland.Core.Tests.csproj
+++ b/tests/DataIsland.Core.Tests/DataIsland.Core.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
It provides an easy way to resolve a custom component or just delegate to an existing patcher.